### PR TITLE
Struik example revisited

### DIFF
--- a/Semantics-Lab/Assistive-Explore.js
+++ b/Semantics-Lab/Assistive-Explore.js
@@ -174,7 +174,6 @@ MathJax.Hub.Register.StartupHook('Sre Ready', function() {
     },
     ActivateWalker: function(math) {
       Explorer.AddSpeech(math);
-      console.log(Explorer.config.walker);
       var speechGenerator = new sre.DirectSpeechGenerator();
       var constructor = Explorer.Walkers[Explorer.config.walker] ||
             Explorer.Walkers['dummy'];

--- a/Semantics-Lab/Assistive-Explore.js
+++ b/Semantics-Lab/Assistive-Explore.js
@@ -174,6 +174,7 @@ MathJax.Hub.Register.StartupHook('Sre Ready', function() {
     },
     ActivateWalker: function(math) {
       Explorer.AddSpeech(math);
+      console.log(Explorer.config.walker);
       var speechGenerator = new sre.DirectSpeechGenerator();
       var constructor = Explorer.Walkers[Explorer.config.walker] ||
             Explorer.Walkers['dummy'];

--- a/Semantics-Lab/Struik.html
+++ b/Semantics-Lab/Struik.html
@@ -5,13 +5,12 @@
 <META http-equiv="X-UA-Compatible" content="IE=edge" />
 <TITLE>MathJax:  Collapsing Differential Geometry Examples</TITLE>
 
-<script src="https://progressiveaccess.com/content/semantic.js"></script>
 <script type="text/x-mathjax-config">
 MathJax.Hub.Config({
   tex2jax: {inlineMath: [['$','$'],['\\(','\\)']]}
 });
 </script>
-<script src="https://rawgit.com/mathjax/MathJax/develop/unpacked/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
+<script src="https://rawgit.com/mathjax/MathJax/develop/unpacked/MathJax.js?config=TeX-AMS_HTML-full"></script>
 <script src="https://progressiveaccess.com/content/sre_mathjax.js"></script>
 <script src="Semantic-MathML.js"></script>
 <script src="Semantic-Collapse.js"></script>

--- a/Semantics-Lab/Struik.html
+++ b/Semantics-Lab/Struik.html
@@ -20,8 +20,9 @@ MathJax.Hub.Config({
 <script>
 MathJax.Extension.SemanticMathML.Enable();
 MathJax.Hub.Queue(function () {
-MathJax.Extension.Lab.setExplorerOption({walker: "syntactic", highlight: "flame",
-background: "blue", foreground: "black"});
+MathJax.Extension.Explorer.config = {walker: "syntactic", highlight: "flame",
+background: "blue", foreground: "black"};
+MathJax.Extension.Explorer.Reset();
 return MathJax.Extension.Collapse.CollapseWideMath()});
 </script>
 

--- a/Semantics-Lab/Struik.html
+++ b/Semantics-Lab/Struik.html
@@ -11,13 +11,18 @@ MathJax.Hub.Config({
   tex2jax: {inlineMath: [['$','$'],['\\(','\\)']]}
 });
 </script>
-<SCRIPT SRC="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML-full"></SCRIPT>
-<script src="InputHooks.js"></script>
+<script src="https://rawgit.com/mathjax/MathJax/develop/unpacked/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
+<script src="https://progressiveaccess.com/content/sre_mathjax.js"></script>
 <script src="Semantic-MathML.js"></script>
 <script src="Semantic-Collapse.js"></script>
+<script src="Assistive-Explore.js"></script>
+<script src="Semantic-Action-Collapse-All.js"></script>
 <script>
 MathJax.Extension.SemanticMathML.Enable();
-MathJax.Hub.Queue(function () {return MathJax.Extension.Collapse.CollapseWideMath()});
+MathJax.Hub.Queue(function () {
+MathJax.Extension.Lab.setExplorerOption({walker: "syntactic", highlight: "flame",
+background: "blue", foreground: "black"});
+return MathJax.Extension.Collapse.CollapseWideMath()});
 </script>
 
 </HEAD>


### PR DESCRIPTION
The example works now with collapse. Walking, highlighting only works for the display expressions. The inline expressions are not being enriched.