### PR TITLE
switch MathJax.js source

### DIFF
--- a/Semantics-Lab/Semantics-Lab-MML-linebreaking.html
+++ b/Semantics-Lab/Semantics-Lab-MML-linebreaking.html
@@ -270,7 +270,7 @@ MathJax.Hub.Config({
 
 }());
 </script>
-<script src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=MML_HTMLorMML"></script>
+<script src="https://beta.mathjax.org/mathjax/develop/unpacked/MathJax.js?config=MML_HTMLorMML"></script>
 
   <p>
 <table border="0" cellpadding="0" cellspacing="2">

--- a/Semantics-Lab/Semantics-Lab-MML.html
+++ b/Semantics-Lab/Semantics-Lab-MML.html
@@ -12,7 +12,7 @@ MathJax.Hub.Config({
   MMLorHTML: {MSIE: "HTML"}
 });
 </script>
-<script src="https://rawgit.com/mathjax/MathJax/develop/unpacked/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
+<script src="https://beta.mathjax.org/mathjax/develop/unpacked/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
 <script src="https://progressiveaccess.com/content/sre_mathjax.js"></script>
 <script src="Semantic-MathML.js"></script>
 <script src="Semantic-Collapse.js"></script>

--- a/Semantics-Lab/Semantics-Lab-TeX-linebreaking.html
+++ b/Semantics-Lab/Semantics-Lab-TeX-linebreaking.html
@@ -260,7 +260,7 @@ MathJax.Hub.Config({
   }
 
 }());</script>
-<script src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML"></script>
+<script src="https://beta.mathjax.org/mathjax/develop/unpacked/MathJax.js?config=TeX-AMS_HTML"></script>
 </head>
 <body>
 

--- a/Semantics-Lab/Semantics-Lab-TeX.html
+++ b/Semantics-Lab/Semantics-Lab-TeX.html
@@ -12,7 +12,7 @@ MathJax.Hub.Config({
   MMLorHTML: {MSIE: "HTML"}
 });
 </script>
-<script src="https://rawgit.com/mathjax/MathJax/develop/unpacked/MathJax.js?config=TeX-AMS_HTML-full"></script>
+<script src="https://beta.mathjax.org/mathjax/develop/unpacked/MathJax.js?config=TeX-AMS_HTML-full"></script>
 <script src="https://progressiveaccess.com/content/sre_mathjax.js"></script>
 <script src="Semantic-MathML.js"></script>
 <script src="Semantic-Collapse.js"></script>

--- a/Semantics-Lab/Struik.html
+++ b/Semantics-Lab/Struik.html
@@ -10,7 +10,7 @@ MathJax.Hub.Config({
   tex2jax: {inlineMath: [['$','$'],['\\(','\\)']]}
 });
 </script>
-<script src="https://rawgit.com/mathjax/MathJax/develop/unpacked/MathJax.js?config=TeX-AMS_HTML-full"></script>
+<script src="https://beta.mathjax.org/mathjax/develop/unpacked/MathJax.js?config=TeX-AMS_HTML-full"></script>
 <script src="https://progressiveaccess.com/content/sre_mathjax.js"></script>
 <script src="Semantic-MathML.js"></script>
 <script src="Semantic-Collapse.js"></script>
@@ -86,7 +86,7 @@ $$
 Hence
 
 $$
-{d{\bf y}\over ds} = {\bf t}(1-a_1\kappa) + {\bf n}\left({da_1\over 
+{d{\bf y}\over ds} = {\bf t}(1-a_1\kappa) + {\bf n}\left({da_1\over
 ds}-\tau a_2\right) + {\bf b}\left({da_2\over ds}+\tau a_1\right)
 $$
 
@@ -116,7 +116,7 @@ $$
 
 The equation of the evolute is:
 $$
-{\bf y} = {\bf x} + R\left[{\bf n} + {\rm cot}\left(\int \tau\,ds + {\rm 
+{\bf y} = {\bf x} + R\left[{\bf n} + {\rm cot}\left(\int \tau\,ds + {\rm
 const}\right){\bf b}\right].
 $$
 
@@ -136,7 +136,7 @@ then according to Green's theorem and the expression in Chapter 2, Eq.
 
 $$
 \int_C P\,du + Q\, dv =
- \int\!\!\!\int_A \left({\partial Q\over \partial u} - {\partial P\over 
+ \int\!\!\!\int_A \left({\partial Q\over \partial u} - {\partial P\over
  \partial v}\right) {1\over \sqrt{EG-F^2}}\,dA,
 $$
 where $dA$ is the element of area of the region $R$ enclosed by the curve
@@ -151,7 +151,7 @@ point $P$ makes the angle $\theta$ with the coordinate curve $v = {\rm
 constant}$ and if the coordinate curves are orthogonal, then, according to
 Liouville's formula (1-13):
 $$
-\kappa_g\,ds = d\theta + \kappa_1(\cos\theta)\,ds + 
+\kappa_g\,ds = d\theta + \kappa_1(\cos\theta)\,ds +
 \kappa_2(\sin\theta)\,ds.
 $$
 
@@ -162,18 +162,18 @@ $$
 $$
 we find by application of Green's theorem:
 $$
-\int_C\kappa_g\,ds = \int_C d\theta + 
-\int\!\!\!\int_A\left({\partial\over\partial u} \left(\kappa_2\sqrt{G}\,\right) - 
+\int_C\kappa_g\,ds = \int_C d\theta +
+\int\!\!\!\int_A\left({\partial\over\partial u} \left(\kappa_2\sqrt{G}\,\right) -
 {\partial\over \partial v}\left(\kappa_1\sqrt{E}\,\right)\right)\,du\,dv.
 $$
 
 <p>
 The Gaussian curvature can be written, according to Chapter 3, Eq. (3-7),
 $$
-K = -{1\over 2\sqrt{EG}} \left[{\partial\over\partial u}{G_u\over 
+K = -{1\over 2\sqrt{EG}} \left[{\partial\over\partial u}{G_u\over
 \sqrt{EG}} + {\partial\over\partial v}{E_v\over\sqrt{EG}}\right]
 ={1\over\sqrt{EG}}\left[ -{\partial\over\partial u}
-\left(\kappa_2\sqrt{G}\,\right) + {\partial\over\partial v} 
+\left(\kappa_2\sqrt{G}\,\right) + {\partial\over\partial v}
 \left(\kappa_1\sqrt{E}\,\right)\right],
 $$
 so we obtain the formula


### PR DESCRIPTION
Use copy of the develop branch on the beta CDN.

Fixes #27 