### PR TITLE
Two versions of the labelled text area.

### DIFF
--- a/Semantics-Lab/MathML.html
+++ b/Semantics-Lab/MathML.html
@@ -97,7 +97,7 @@ MathJax.Hub.config.extensions.push(
 
 <table border="0" cellpadding="0" cellspacing="2">
 <table border="0" cellpadding="0" cellspacing="2">
-<tr><td align="left" colspan="2">Enter MathMLcode here:</td></tr>
+<tr><td align="left" colspan="2"><label for="input">Enter MathML code here:</label></td></tr>
 <tr><td colspan="2"><textarea id="input" rows="10" cols="60" onkeypress="Lab.CheckKey(event)" style="font-size:110%"></textarea></td></tr>
 <tr>
 <td align="left">

--- a/Semantics-Lab/TeX.html
+++ b/Semantics-Lab/TeX.html
@@ -128,8 +128,8 @@ input[type="checkbox"] {margin-left: 0}
 </div>
 
 <table border="0" cellpadding="0" cellspacing="2">
-<tr><td align="left" colspan="2">Enter TeX code here:</td></tr>
-<tr><td colspan="2"><textarea aria-label="Enter TeX code here:" id="input" rows="10" cols="60" onkeypress="Lab.CheckKey(event)" style="font-size:110%"></textarea></td></tr>
+<tr><td align="left" colspan="2"><label for="input">Enter TeX code here:</label></td></tr>
+<tr><td colspan="2"><textarea id="input" rows="10" cols="60" onkeypress="Lab.CheckKey(event)" style="font-size:110%"></textarea></td></tr>
 <tr>
   <td align="left">
   Examples: <select onchange="Lab.Select(this.value)" id="example">

--- a/Semantics-Lab/TeX.html
+++ b/Semantics-Lab/TeX.html
@@ -129,9 +129,9 @@ input[type="checkbox"] {margin-left: 0}
 
 <table border="0" cellpadding="0" cellspacing="2">
 <tr><td align="left" colspan="2">Enter TeX code here:</td></tr>
-<tr><td colspan="2"><textarea id="input" rows="10" cols="60" onkeypress="Lab.CheckKey(event)" style="font-size:110%"></textarea></td></tr>
+<tr><td colspan="2"><textarea aria-label="Enter TeX code here:" id="input" rows="10" cols="60" onkeypress="Lab.CheckKey(event)" style="font-size:110%"></textarea></td></tr>
 <tr>
-<td align="left">
+  <td align="left">
   Examples: <select onchange="Lab.Select(this.value)" id="example">
   <option value="0">(Select one)</option>
   <option value="-">----------------</option>


### PR DESCRIPTION
This is a step towards fixing issue #57.

In TeX.html, we add an aria-label. This way the textarea is announced and the original description is also reachable from the screen reader.

In MathML.html, we turn the description into a label. This takes it out of the normal flow for the screenreader it will only be read twice if the entire table is selected.

Personally I think the latter is good, but have a look.