### PR TITLE
Accessibility menu

### DIFF
--- a/Semantics-Lab/Lab.js
+++ b/Semantics-Lab/Lab.js
@@ -107,7 +107,6 @@ var Lab = {
     if (!skipUpdate) {
       MathJax.Hub.Queue(
         ["Reprocess",this.jax[1]],
-        ["ShowMathML",this],
         ["CollapseWideMath",MathJax.Extension.SemanticCollapse]
       );
     }
@@ -207,6 +206,11 @@ MathJax.Hub.Register.StartupHook("Explorer Ready",
                                    Lab.ASSISTIVE = MathJax.Extension.Assistive;
                                    Lab.executeExplorerOptions();
                                  });
+
+//
+// Hook into reprocess as this can be also triggered from the menu.
+//
+MathJax.Hub.Register.MessageHook('End Reprocess', ['ShowMathML', Lab]);
 
 //
 //  Hook into menu renderer changes

--- a/Semantics-Lab/Lab.js
+++ b/Semantics-Lab/Lab.js
@@ -14,8 +14,8 @@ var Lab = {
     background: "blue",
     foreground: "black"
   },
-  // The explorer extension
-  EXPLORER: null,
+  // The assistive extension
+  ASSISTIVE: null,
   //
   //  The TeX code for the examples menu
   //
@@ -48,10 +48,10 @@ var Lab = {
       String(window.location).replace(/\?.*/,"")+"?"
         +[this.example.value, this.width.value, this.renderer.value,
           this.collapse, this.overflow,
-          Lab.EXPLORER.config.walker,
-          Lab.EXPLORER.config.highlight,
-          Lab.EXPLORER.config.background,
-          Lab.EXPLORER.config.foreground,
+          Lab.ASSISTIVE.config.walker,
+          Lab.ASSISTIVE.config.highlight,
+          Lab.ASSISTIVE.config.background,
+          Lab.ASSISTIVE.config.foreground,
           ""].join(';')
         +escape(this.input.value);
   },
@@ -144,9 +144,9 @@ var Lab = {
   //
   explorerOptions: [],
   executeExplorerOptions: function() {
-    while (Lab.EXPLORER && Lab.explorerOptions.length > 0) {
-      Lab.EXPLORER.setExplorerOption.apply(Lab.EXPLORER,
-                                           Lab.explorerOptions.pop());
+    while (Lab.ASSISTIVE && Lab.explorerOptions.length > 0) {
+      Lab.ASSISTIVE.setOption.apply(Lab.ASSISTIVE,
+                                    Lab.explorerOptions.pop());
     }
   },
   setExplorerOption: function(key, value) {
@@ -204,7 +204,7 @@ MathJax.Hub.Register.MessageHook("New Math",["NewMath",Lab]);
 //
 MathJax.Hub.Register.StartupHook("Explorer Ready",
                                  function() {
-                                   Lab.EXPLORER = MathJax.Extension.Explorer;
+                                   Lab.ASSISTIVE = MathJax.Extension.Assistive;
                                    Lab.executeExplorerOptions();
                                  });
 

--- a/Semantics-Lab/Lab.js
+++ b/Semantics-Lab/Lab.js
@@ -216,14 +216,14 @@ MathJax.Hub.Register.StartupHook("MathMenu Ready",function () {
     if (message[0] === "radio button") {
       var variable = message[1].variable;
       if (variable === 'renderer') {
-        Lab.renderer.value = value;
+        Lab.renderer.value = message[1].value;
         return;
       }
       if (String(variable).match(/^Assistive-/)) {
         var key = String(variable).replace('Assistive-', '');
         var element = document.getElementById(key);
         if (element) {
-          element.value = value;
+          element.value = message[1].value;
         }
       }
     }

--- a/Semantics-Lab/Lab.js
+++ b/Semantics-Lab/Lab.js
@@ -214,12 +214,11 @@ MathJax.Hub.Register.StartupHook("Explorer Ready",
 MathJax.Hub.Register.StartupHook("MathMenu Ready",function () {
   MathJax.Extension.MathMenu.signal.Interest(function (message) {
     if (message[0] === "radio button") {
-      var value = message[1].value;
-      if (String(value).match(/^(HTML-CSS|CommonHTML|PreviewHTML|NativeMML|SVG)$/)) {
+      var variable = message[1].variable;
+      if (variable === 'renderer') {
         Lab.renderer.value = value;
         return;
       }
-      var variable = message[1].variable;
       if (String(variable).match(/^Assistive-/)) {
         var key = String(variable).replace('Assistive-', '');
         var element = document.getElementById(key);

--- a/Semantics-Lab/Lab.js
+++ b/Semantics-Lab/Lab.js
@@ -214,9 +214,18 @@ MathJax.Hub.Register.StartupHook("Explorer Ready",
 MathJax.Hub.Register.StartupHook("MathMenu Ready",function () {
   MathJax.Extension.MathMenu.signal.Interest(function (message) {
     if (message[0] === "radio button") {
-      var renderer = message[1].value;
-      if (String(renderer).match(/^(HTML-CSS|CommonHTML|PreviewHTML|NativeMML|SVG)$/)) {
-        Lab.renderer.value = renderer;
+      var value = message[1].value;
+      if (String(value).match(/^(HTML-CSS|CommonHTML|PreviewHTML|NativeMML|SVG)$/)) {
+        Lab.renderer.value = value;
+        return;
+      }
+      var variable = message[1].variable;
+      if (String(variable).match(/^Assistive-/)) {
+        var key = String(variable).replace('Assistive-', '');
+        var element = document.getElementById(key);
+        if (element) {
+          element.value = value;
+        }
       }
     }
   });

--- a/examples/Struik-speech.html
+++ b/examples/Struik-speech.html
@@ -9,14 +9,13 @@
 MathJax.Hub.Config({
   tex2jax: {inlineMath: [['$','$'],['\\(','\\)']]},
   SemanticCollapse: {autoCollapse: true},
-  AssistiveMML: {disabled: true}
+  AssistiveMML: {disabled: true},
+  menuSettings: {'Assistive-walker': 'syntactic'}
 });
 MathJax.Ajax.config.path["RespEq"] = "../extensions"
 MathJax.Hub.config.extensions.push(
 "[RespEq]/Assistive-Explore.js",
 "[RespEq]/Semantic-Collapse.js");
-MathJax.Hub.Register.StartupHook('Explorer Ready', function()
-{MathJax.Extension.Explorer.config.walker = "syntactic";});
 </script>
 <script src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML-full"></script>
 </head>

--- a/examples/Struik.html
+++ b/examples/Struik.html
@@ -8,10 +8,15 @@
 <script type="text/x-mathjax-config">
 MathJax.Hub.Config({
   tex2jax: {inlineMath: [['$','$'],['\\(','\\)']]},
-  SemanticCollapse: {autoCollapse: true}
+  SemanticCollapse: {autoCollapse: true},
+  menuSettings: {'Assistive-generateSpeech': false,
+                 'Assistive-walker': 'syntactic'
+  }
 });
 MathJax.Ajax.config.path["RespEq"] = "../extensions"
-MathJax.Hub.config.extensions.push("[RespEq]/Semantic-Collapse.js");
+MathJax.Hub.config.extensions.push(
+"[RespEq]/Assistive-Explore.js",
+"[RespEq]/Semantic-Collapse.js");
 </script>
 <script src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML-full"></script>
 </head>

--- a/extensions/Assistive-Explore.js
+++ b/extensions/Assistive-Explore.js
@@ -160,7 +160,6 @@ MathJax.Hub.Register.StartupHook('Sre Ready', function() {
     hoverer: null,
     flamer: null,
     speechDiv: null,
-    enriched: {},
     earconFile: location.protocol +
       '//progressiveaccess.com/content/invalid_keypress' +
       (['Firefox', 'Chrome', 'Opera'].indexOf(MathJax.Hub.Browser.name) !== -1 ?
@@ -181,7 +180,6 @@ MathJax.Hub.Register.StartupHook('Sre Ready', function() {
       if (script && script.id) {
         var jax = MathJax.Hub.getJaxFor(script.id);
         if (jax && jax.enriched) {
-          Explorer.enriched[script.id] = script;
           Explorer.liveRegion.Add();
           Explorer.AddEvent(script);
         }
@@ -309,8 +307,8 @@ MathJax.Hub.Register.StartupHook('Sre Ready', function() {
       }
     },
     FlameEnriched: function() {
-      for (var key in Explorer.enriched) {
-        Explorer.Flame(Explorer.enriched[key].previousSibling);
+      for (var i = 0, all = MathJax.Hub.getAllJax(), jax; jax = all[i]; i++) {
+        Explorer.Flame(document.getElementById(jax.inputID).previousSibling);
       }
     },
     // 
@@ -382,7 +380,7 @@ MathJax.Hub.Register.StartupHook('Sre Ready', function() {
           if (item) {
             item.disabled = !item.disabled;
           }});
-      for (var jax in MathJax.Hub.getAllJax()) {
+      for (var i = 0, all = MathJax.Hub.getAllJax(), jax; jax = all[i]; i++) {
         if (jax.enriched) {
           // This does not yet work!
           MathJax.Extension.SemanticMathML(jax); 
@@ -404,8 +402,8 @@ MathJax.Hub.Register.StartupHook('Sre Ready', function() {
                   ITEM.RADIO(['semantic', 'Semantic walker'], 'Assistive-walker')
                           ),
               ITEM.SUBMENU(['Highlight', 'Highlight'],
-                           ITEM.RADIO(['none', 'None'], 'Assistive-highlight'),
-                           ITEM.RADIO(['hover', 'Hover'], 'Assistive-highlight'),
+                           ITEM.RADIO(['none', 'None'], 'Assistive-highlight', {action: Explorer.Reset}),
+                           ITEM.RADIO(['hover', 'Hover'], 'Assistive-highlight', {action: Explorer.Reset}),
                            ITEM.RADIO(['flame','Flame'], 'Assistive-highlight', {action: Explorer.Reset})
                           ),
               ITEM.SUBMENU(['Background', 'Background'],

--- a/extensions/Assistive-Explore.js
+++ b/extensions/Assistive-Explore.js
@@ -411,8 +411,15 @@ MathJax.Hub.Register.StartupHook('Sre Ready', function() {
               ITEM.CHECKBOX(['Speech', 'Speech Output'], 'Assistive-speech'),
               ITEM.CHECKBOX(['Subtitles', 'Subtitles'], 'Assistive-subtitle')
                       );
-    MathJax.Menu.menu.items.push(ITEM.RULE());
-    MathJax.Menu.menu.items.push(accessibiltyMenu);
+    // Attaches the menu;
+    var about = MathJax.Menu.menu.IndexOfId('About');
+    if (about === null) {
+      MathJax.Menu.menu.items.push(ITEM.RULE());
+      MathJax.Menu.menu.items.push(accessibiltyMenu);
+      return;
+    }
+    MathJax.Menu.menu.items.splice(about, 0, ITEM.RULE());
+    MathJax.Menu.menu.items.splice(about, 0, accessibiltyMenu);
   });
 
   MathJax.Hub.Register.MessageHook('New Math', ['Register', MathJax.Extension.Assistive.Explorer]);

--- a/extensions/Assistive-Explore.js
+++ b/extensions/Assistive-Explore.js
@@ -215,7 +215,6 @@ MathJax.Hub.Register.StartupHook('Sre Ready', function() {
           return;
         }
       }
-      MathJax.Hub.Queue(['AddEvent', Explorer, script]);
     },
     //
     // Event execution on keydown. Subsumes the same method of MathEvents.
@@ -373,6 +372,7 @@ MathJax.Hub.Register.StartupHook('Sre Ready', function() {
     // Regenerates speech.
     //
     Regenerate: function() {
+      Explorer.Reset();
       var speechItems = ['SpeechOutput', 'Subtitles'];
       speechItems.forEach(
         function(x) {
@@ -382,9 +382,7 @@ MathJax.Hub.Register.StartupHook('Sre Ready', function() {
           }});
       for (var i = 0, all = MathJax.Hub.getAllJax(), jax; jax = all[i]; i++) {
         if (jax.enriched) {
-          // This does not yet work!
-          MathJax.Extension.SemanticMathML(jax); 
-          MathJax.Hub.Reprocess(jax); 
+          MathJax.Hub.Queue(['Reprocess', jax]);
         }
       }
     }

--- a/extensions/Assistive-Explore.js
+++ b/extensions/Assistive-Explore.js
@@ -56,7 +56,7 @@ MathJax.Hub.Register.StartupHook('Sre Ready', function() {
     div: null,
     inner: null,
     Init: function() {
-      this.div = LiveRegion.Create('assertive', LiveRegion.hidden);
+      this.div = LiveRegion.Create('assertive');
       this.inner = MathJax.HTML.addElement(this.div,'div');
     },
     //
@@ -71,9 +71,7 @@ MathJax.Hub.Register.StartupHook('Sre Ready', function() {
     // Shows the live region as a subtitle of a node.
     //
     Show: function(node, highlighter) {
-      for (var key in LiveRegion.subtitle) {
-        this.div.style[key] = LiveRegion.subtitle[key];
-      }
+      this.div.classList.add('MJX_LiveRegion_Show');
       var rect = node.getBoundingClientRect();
       var bot = rect.bottom + 10 + window.pageYOffset;
       var left = rect.left + window.pageXOffset;
@@ -87,9 +85,7 @@ MathJax.Hub.Register.StartupHook('Sre Ready', function() {
     // Takes the live region out of the page flow.
     //
     Hide: function(node) {
-      for (var key in LiveRegion.hidden) {
-        this.div.style[key] = LiveRegion.hidden[key];
-      }
+      this.div.classList.remove('MJX_LiveRegion_Show');
     },
     //
     // Clears the speech div.
@@ -110,20 +106,25 @@ MathJax.Hub.Register.StartupHook('Sre Ready', function() {
   }, {
     ANNOUNCE: 'Navigatable Math in page. Explore with shift space.',
     announced: false,
-    hidden: {position: 'absolute', top:'0', height: '1px', width: '1px',
-             padding: '1px', overflow: 'hidden'},
-    subtitle: {position: 'absolute', width: 'auto', height: 'auto',
-               padding: '5px 0px', opacity: 1, 'z-index': '202',
+    styles: {'.MJX_LiveRegion':
+             {
+               position: 'absolute', top:'0', height: '1px', width: '1px',
+               padding: '1px', overflow: 'hidden'
+             },
+             '.MJX_LiveRegion_Show':
+             {
+               top:'0', position: 'absolute', width: 'auto', height: 'auto',
+               padding: '0px 0px', opacity: 1, 'z-index': '202',
                left: 0, right: 0, 'margin': '0 auto',
-               backgroundColor: 'white'
-              },
-
+               'background-color': 'white', 'box-shadow': '0px 10px 20px #888',
+               border: '2px solid #CCCCCC'
+             }},
     //
-    // Creates a live region with a particular type and display style.
+    // Creates a live region with a particular type.
     //
-    Create: function(type, style) {
+    Create: function(type) {
       var element = MathJax.HTML.Element(
-        'div', {className: 'MathJax_SpeechOutput', style: style});
+        'div', {className: 'MJX_LiveRegion'});
       element.setAttribute('aria-live', type);
       return element;
     },
@@ -143,7 +144,8 @@ MathJax.Hub.Register.StartupHook('Sre Ready', function() {
     Announce: function() {
       if (LiveRegion.announced) return;
       LiveRegion.announced = true;
-      var div = LiveRegion.Create('polite', LiveRegion.hidden);
+      MathJax.Ajax.Styles(LiveRegion.styles);
+      var div = LiveRegion.Create('polite');
       document.body.appendChild(div);
       LiveRegion.Update(div, LiveRegion.ANNOUNCE);
       setTimeout(function() {document.body.removeChild(div);}, 1000);

--- a/extensions/Assistive-Explore.js
+++ b/extensions/Assistive-Explore.js
@@ -11,6 +11,7 @@ MathJax.Hub.Register.StartupHook('Sre Ready', function() {
   });
 
   var Assistive = MathJax.Extension.Assistive = {
+    version: "1.0",
     //
     // Default configurations.
     //
@@ -52,8 +53,6 @@ MathJax.Hub.Register.StartupHook('Sre Ready', function() {
   };
   
   var LiveRegion = MathJax.Object.Subclass({
-    version: "1.0",
-    
     div: null,
     inner: null,
     Init: function() {
@@ -153,8 +152,6 @@ MathJax.Hub.Register.StartupHook('Sre Ready', function() {
   MathJax.Extension.Assistive.LiveRegion = LiveRegion;
   
   var Explorer = MathJax.Extension.Assistive.Explorer = {
-    version: "1.0",
-    
     liveRegion: LiveRegion(),
     walker: null,
     highlighter: null,

--- a/extensions/Assistive-Explore.js
+++ b/extensions/Assistive-Explore.js
@@ -32,7 +32,7 @@ MathJax.Hub.Register.StartupHook('Sre Ready', function() {
     },
 
     addDefaults: function() {
-      for (var key in Assistive.default) {
+      for (var key in Object.keys(Assistive.default)) {
         if (typeof(SETTINGS[Assistive.prefix + key]) === 'undefined') {
           Assistive.addMenuOption(key, Assistive.default[key]);
         }
@@ -328,10 +328,13 @@ MathJax.Hub.Register.StartupHook('Sre Ready', function() {
       Explorer.walker = new constructor(math, speechGenerator);
       Explorer.GetHighlighter(.2);
       Explorer.walker.activate();
-      if (Assistive.getOption('subtitle')) {
-        Explorer.liveRegion.Show(math, Explorer.highlighter);
+      if (Assistive.getOption('generateSpeech') &&
+          Assistive.getOption('speech')) {
+        if (Assistive.getOption('subtitle')) {
+          Explorer.liveRegion.Show(math, Explorer.highlighter);
+        }
+        Explorer.liveRegion.Update(Explorer.walker.speech());
       }
-      Explorer.liveRegion.Update(Explorer.walker.speech());
       Explorer.Highlight();
     },
     //
@@ -367,6 +370,25 @@ MathJax.Hub.Register.StartupHook('Sre Ready', function() {
     PlayEarcon: function() {
       var audio = new Audio(Explorer.earconFile);
       audio.play();
+    },
+    //
+    // Regenerates speech.
+    //
+    Regenerate: function() {
+      var speechItems = ['SpeechOutput', 'Subtitles'];
+      speechItems.forEach(
+        function(x) {
+          var item = MathJax.Menu.menu.FindId('Accessibility', x);
+          if (item) {
+            item.disabled = !item.disabled;
+          }});
+      for (var jax in MathJax.Hub.getAllJax()) {
+        if (jax.enriched) {
+          // This does not yet work!
+          MathJax.Extension.SemanticMathML(jax); 
+          MathJax.Hub.Reprocess(jax); 
+        }
+      }
     }
   };
 
@@ -406,9 +428,13 @@ MathJax.Hub.Register.StartupHook('Sre Ready', function() {
                            ITEM.RADIO(['red','Red'], 'Assistive-foreground', {action: Explorer.Reset}),
                            ITEM.RADIO(['blue','Blue'], 'Assistive-foreground', {action: Explorer.Reset})
                           ),
-              ITEM.RULE(),
-              ITEM.CHECKBOX(['Speech', 'Speech Output'], 'Assistive-speech'),
-              ITEM.CHECKBOX(['Subtitles', 'Subtitles'], 'Assistive-subtitle')
+                       ITEM.RULE(),
+                       ITEM.CHECKBOX(['GenerateSpeech', 'Generate Speech'], 'Assistive-generateSpeech',
+                                     {action: Explorer.Regenerate}),
+                       ITEM.CHECKBOX(['SpeechOutput', 'Speech Output'], 'Assistive-speech',
+                                     {disabled: !SETTINGS['Assistive-generateSpeech']}),
+                       ITEM.CHECKBOX(['Subtitles', 'Subtitles'], 'Assistive-subtitle',
+                                     {disabled: !SETTINGS['Assistive-generateSpeech']})
                       );
     // Attaches the menu;
     var about = MathJax.Menu.menu.IndexOfId('About');

--- a/extensions/Assistive-Explore.js
+++ b/extensions/Assistive-Explore.js
@@ -374,10 +374,10 @@ MathJax.Hub.Register.StartupHook('Sre Ready', function() {
 
   MathJax.Hub.Register.StartupHook('MathMenu Ready', function() {
     var ITEM = MathJax.Menu.ITEM;
-    var accessibiltyMenu =
+    var accessibilityMenu =
           ITEM.SUBMENU(['Accessibility', 'Accessibilty'],
               ITEM.SUBMENU(['Walker', 'Walker'],
-                  ITEM.RADIO(['dummy', 'Dummy walker'], 'Assistive-walker'),
+                  ITEM.RADIO(['dummy', 'No walker'], 'Assistive-walker'),
                   ITEM.RADIO(['syntactic', 'Syntax walker'], 'Assistive-walker'),
                   ITEM.RADIO(['semantic', 'Semantic walker'], 'Assistive-walker')
                           ),
@@ -413,12 +413,10 @@ MathJax.Hub.Register.StartupHook('Sre Ready', function() {
     // Attaches the menu;
     var about = MathJax.Menu.menu.IndexOfId('About');
     if (about === null) {
-      MathJax.Menu.menu.items.push(ITEM.RULE());
-      MathJax.Menu.menu.items.push(accessibiltyMenu);
+      MathJax.Menu.menu.items.push(ITEM.RULE(), accessibilityMenu);
       return;
     }
-    MathJax.Menu.menu.items.splice(about, 0, ITEM.RULE());
-    MathJax.Menu.menu.items.splice(about, 0, accessibiltyMenu);
+    MathJax.Menu.menu.items.splice(about, 0, accessibilityMenu, ITEM.RULE());
   });
 
   MathJax.Hub.Register.MessageHook('New Math', ['Register', MathJax.Extension.Assistive.Explorer]);

--- a/extensions/Assistive-Explore.js
+++ b/extensions/Assistive-Explore.js
@@ -3,6 +3,8 @@
 //
 MathJax.Hub.Register.StartupHook('Sre Ready', function() {
   var FALSE, KEY;
+  var SETTINGS = MathJax.Hub.config.menuSettings;
+
   MathJax.Hub.Register.StartupHook('MathEvents Ready', function() {
     FALSE = MathJax.Extension.MathEvents.Event.False;
     KEY = MathJax.Extension.MathEvents.Event.KEY;
@@ -10,9 +12,9 @@ MathJax.Hub.Register.StartupHook('Sre Ready', function() {
 
   var Assistive = MathJax.Extension.Assistive = {
     //
-    // Configurations.
+    // Default configurations.
     //
-    config: {
+    default: {
       walker: 'dummy',
       highlight: 'none',
       background: 'blue',
@@ -20,27 +22,27 @@ MathJax.Hub.Register.StartupHook('Sre Ready', function() {
       speech: true,
       subtitle: true
     },
-
+    prefix: 'Assistive-',
+    
     addMenuOption: function(key, value) {
-      MathJax.Hub.config.menuSettings['Assistive-' + key] = value;      
+      SETTINGS[Assistive.prefix + key] = value;      
     },
 
-    addMenuOptions: function() {
-      for (var key in Assistive.config) {
-        Assistive.addMenuOption(key, Assistive.config[key]);
+    addDefaults: function() {
+      for (var key in Assistive.default) {
+        Assistive.addMenuOption(key, Assistive.default[key]);
       }
+      Explorer.Reset();
     },
 
     setOption: function(key, value) {
-      if (Assistive.config[key] === value) return;
-      Assistive.config[key] = value;
+      if (SETTINGS[Assistive.prefix + key] === value) return;
       Assistive.addMenuOption(key, value);
       Explorer.Reset();
     },
 
     getOption: function(key) {
-      var value = MathJax.Hub.config.menuSettings['Assistive-' + key];
-      return (typeof(value) !== 'undefined') ? value : Assistive.config[key]; 
+      return SETTINGS[Assistive.prefix + key];
     }
     
   };
@@ -365,9 +367,10 @@ MathJax.Hub.Register.StartupHook('Sre Ready', function() {
     }
   };
 
+  MathJax.Extension.Assistive.addDefaults();
+
   MathJax.Hub.Register.StartupHook('MathMenu Ready', function() {
     var ITEM = MathJax.Menu.ITEM;
-    MathJax.Extension.Assistive.addMenuOptions();
     var accessibiltyMenu =
           ITEM.SUBMENU(['Accessibility', 'Accessibilty'],
               ITEM.SUBMENU(['Walker', 'Walker'],
@@ -406,7 +409,6 @@ MathJax.Hub.Register.StartupHook('Sre Ready', function() {
                       );
     MathJax.Menu.menu.items.push(ITEM.RULE());
     MathJax.Menu.menu.items.push(accessibiltyMenu);
-    Explorer.Reset();
   });
 
   MathJax.Hub.Register.MessageHook('New Math', ['Register', MathJax.Extension.Assistive.Explorer]);

--- a/extensions/Assistive-Explore.js
+++ b/extensions/Assistive-Explore.js
@@ -20,7 +20,9 @@ MathJax.Hub.Register.StartupHook('Sre Ready', function() {
       background: 'blue',
       foreground: 'black',
       speech: true,
-      subtitle: true
+      subtitle: true,
+      // Configuration option only.
+      generateSpeech: true
     },
     prefix: 'Assistive-',
     
@@ -30,7 +32,9 @@ MathJax.Hub.Register.StartupHook('Sre Ready', function() {
 
     addDefaults: function() {
       for (var key in Assistive.default) {
-        Assistive.addMenuOption(key, Assistive.default[key]);
+        if (typeof(SETTINGS[Assistive.prefix + key]) === 'undefined') {
+          Assistive.addMenuOption(key, Assistive.default[key]);
+        }
       }
       Explorer.Reset();
     },
@@ -168,7 +172,7 @@ MathJax.Hub.Register.StartupHook('Sre Ready', function() {
     //
     Reset: function() {
       Explorer.FlameEnriched();
-      sre.Engine.getInstance().speech = Assistive.getOption('speech');
+      sre.Engine.getInstance().speech = Assistive.getOption('generateSpeech');
     },
     //
     // Registers new Maths and adds a key event if it is enriched.
@@ -375,7 +379,7 @@ MathJax.Hub.Register.StartupHook('Sre Ready', function() {
           ITEM.SUBMENU(['Accessibility', 'Accessibilty'],
               ITEM.SUBMENU(['Walker', 'Walker'],
                   ITEM.RADIO(['dummy', 'Dummy walker'], 'Assistive-walker', {action: Explorer.Reset}),
-                  ITEM.RADIO(['syntax', 'Syntax walker'], 'Assistive-walker', {action: Explorer.Reset}),
+                  ITEM.RADIO(['syntactic', 'Syntax walker'], 'Assistive-walker', {action: Explorer.Reset}),
                   ITEM.RADIO(['semantic', 'Semantic walker'], 'Assistive-walker', {action: Explorer.Reset})
                           ),
               ITEM.SUBMENU(['Highlight', 'Highlight'],

--- a/extensions/Assistive-Explore.js
+++ b/extensions/Assistive-Explore.js
@@ -8,7 +8,6 @@ MathJax.Hub.Register.StartupHook('Sre Ready', function() {
     KEY = MathJax.Extension.MathEvents.Event.KEY;
   });
 
-
   var LiveRegion = MathJax.Extension.LiveRegion = MathJax.Object.Subclass({
     version: "1.0",
     
@@ -39,6 +38,9 @@ MathJax.Hub.Register.StartupHook('Sre Ready', function() {
   }, {
     ANNOUNCE: 'Navigatable Math in page. Explore with shift space.',
     announced: false,
+    hidden: {position: 'absolute', top:'0', height: '1px', width: '1px',
+             padding: '1px', overflow: 'hidden'},
+
     //
     // Creates a live region with a particular type and display style.
     //
@@ -64,8 +66,7 @@ MathJax.Hub.Register.StartupHook('Sre Ready', function() {
     Announce: function() {
       if (LiveRegion.announced) return;
       LiveRegion.announced = true;
-      var div = LiveRegion.Create('polite',
-                                  {fontSize: '1px', color: '#FFFFFF'});
+      var div = LiveRegion.Create('polite', LiveRegion.hidden);
       document.body.appendChild(div);
       LiveRegion.Update(div, LiveRegion.ANNOUNCE);
       setTimeout(function() {document.body.removeChild(div);}, 1000);
@@ -98,6 +99,7 @@ MathJax.Hub.Register.StartupHook('Sre Ready', function() {
       foreground: 'black',
       speech: true
     },
+
     setExplorerOption: function(key, value) {
       if (Explorer.config[key] === value) return;
       Explorer.config[key] = value;

--- a/extensions/Assistive-Explore.js
+++ b/extensions/Assistive-Explore.js
@@ -20,7 +20,7 @@ MathJax.Hub.Register.StartupHook('Sre Ready', function() {
       background: 'blue',
       foreground: 'black',
       speech: true,
-      subtitle: true,
+      subtitle: false,
       // Configuration option only.
       generateSpeech: true
     },

--- a/extensions/Assistive-Explore.js
+++ b/extensions/Assistive-Explore.js
@@ -378,13 +378,13 @@ MathJax.Hub.Register.StartupHook('Sre Ready', function() {
     var accessibiltyMenu =
           ITEM.SUBMENU(['Accessibility', 'Accessibilty'],
               ITEM.SUBMENU(['Walker', 'Walker'],
-                  ITEM.RADIO(['dummy', 'Dummy walker'], 'Assistive-walker', {action: Explorer.Reset}),
-                  ITEM.RADIO(['syntactic', 'Syntax walker'], 'Assistive-walker', {action: Explorer.Reset}),
-                  ITEM.RADIO(['semantic', 'Semantic walker'], 'Assistive-walker', {action: Explorer.Reset})
+                  ITEM.RADIO(['dummy', 'Dummy walker'], 'Assistive-walker'),
+                  ITEM.RADIO(['syntactic', 'Syntax walker'], 'Assistive-walker'),
+                  ITEM.RADIO(['semantic', 'Semantic walker'], 'Assistive-walker')
                           ),
               ITEM.SUBMENU(['Highlight', 'Highlight'],
-                           ITEM.RADIO(['none', 'None'], 'Assistive-highlight', {action: Explorer.Reset}),
-                           ITEM.RADIO(['hover', 'Hover'], 'Assistive-highlight', {action: Explorer.Reset}),
+                           ITEM.RADIO(['none', 'None'], 'Assistive-highlight'),
+                           ITEM.RADIO(['hover', 'Hover'], 'Assistive-highlight'),
                            ITEM.RADIO(['flame','Flame'], 'Assistive-highlight', {action: Explorer.Reset})
                           ),
               ITEM.SUBMENU(['Background', 'Background'],
@@ -408,8 +408,8 @@ MathJax.Hub.Register.StartupHook('Sre Ready', function() {
                            ITEM.RADIO(['blue','Blue'], 'Assistive-foreground', {action: Explorer.Reset})
                           ),
               ITEM.RULE(),
-              ITEM.CHECKBOX(['Speech', 'Speech Output'], 'Assistive-speech', {action: Explorer.Reset}),
-              ITEM.CHECKBOX(['Subtitles', 'Subtitles'], 'Assistive-subtitle', {action: Explorer.Reset})
+              ITEM.CHECKBOX(['Speech', 'Speech Output'], 'Assistive-speech'),
+              ITEM.CHECKBOX(['Subtitles', 'Subtitles'], 'Assistive-subtitle')
                       );
     MathJax.Menu.menu.items.push(ITEM.RULE());
     MathJax.Menu.menu.items.push(accessibiltyMenu);


### PR DESCRIPTION
* Integrates the AT options into a submenu.
* Revamps the subtitling and adds an option to switch it on or off.
* There is probably a nicer way to deal with config options and make the available to the menu, but I don't really know how.
* It does not yet integrate well with the Lab and combobox options. I could duplicate code similar to renderer setting, but would like an explanation of the following code snippets first from @dpvc 

  //
  //  The renderer selection
  //
  setRenderer: function (mode,skipUpdate) {
    MathJax.Hub.Queue(["setRenderer",MathJax.Hub,mode,"jax/mml"]);
    if (!skipUpdate) MathJax.Hub.Queue(["Rerender",MathJax.Hub]);
  },
  

//
//  Hook into menu renderer changes
//
MathJax.Hub.Register.StartupHook("MathMenu Ready",function () {
  MathJax.Extension.MathMenu.signal.Interest(function (message) {
    if (message[0] === "radio button") {
      var renderer = message[1].value;
      if (String(renderer).match(/^(HTML-CSS|CommonHTML|PreviewHTML|NativeMML|SVG)$/)) {
        Lab.renderer.value = renderer;
      }
    }
  });
});