### PR TITLE
Enriches Inline expressions

### DIFF
--- a/examples/Struik-speech.html
+++ b/examples/Struik-speech.html
@@ -1,0 +1,191 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta http-equiv="X-UA-Compatible" content="IE=edge" />
+<title>MathJax:  Collapsing Differential Geometry Examples</title>
+
+<script type="text/x-mathjax-config">
+MathJax.Hub.Config({
+  tex2jax: {inlineMath: [['$','$'],['\\(','\\)']]},
+  SemanticCollapse: {autoCollapse: true},
+  AssistiveMML: {disabled: true},
+});
+MathJax.Ajax.config.path["RespEq"] = "../extensions"
+MathJax.Hub.config.extensions.push(
+"[RespEq]/Assistive-Explore.js",
+"[RespEq]/Semantic-Collapse.js");
+MathJax.Hub.Register.StartupHook('Explorer Ready', function()
+{MathJax.Extension.Explorer.config.walker = "syntactic";});
+</script>
+<script src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML-full"></script>
+</head>
+<body>
+
+<blockquote>
+
+<h1>An example from Struik's <i>Lectures on Classical Differential Geometry</i></h1>
+
+<!------------------------------------------------------------------------>
+<hr>
+<div id="p23">
+p. 23
+<p>
+
+<blockquote>
+
+<p>
+This procedure is simply a generalization of the method used in Sects.
+1-3 and 1-4 to obtain the equations of the osculating plane and the
+osculating circle.  Let $f(u)$ near $P(u=u_0)$ have finite derivatives
+$f^{(i)}(u_0)$, $i = 1, 2, \ldots, n+1$.  Then if we take $u=u_1$ at $A$
+and write $h = u_1 - u_0$, then there exists a Taylor development of $f(u)$
+of the form (compare Eq.  (1-5)):
+$$
+f(u_1) = f(u_0) + hf'(u_0)+{h^2\over 2!}f''(u_0) + \cdots
+ + {h^{n+1}\over (n+1)!}f^{(n+1)}(u_0) + o(h^{n+1}).
+$$
+
+Here, $f(u_0)=0$ since $P$ lies on $\Sigma_2$, and $h$ is of order $AP$
+(see theorem Sec.  1-2); $f(u_1)$ is of order $AD$.  <i>Hence necessary and
+sufficient conditions that the surface has a contact of order $n$ at $P$
+with the curve are that at $P$ the relations hold:</i>
+
+$$
+f(u) = f'(u) = f''(u) = \cdots = f^{(n)}(u) = 0;\quad f^{(n+1)}(u) \ne 0.
+$$
+
+</blockquote>
+
+<!------------------------------------------------------------------------>
+<hr>
+<div id="p40">
+p. 40
+<p>
+
+<blockquote>
+
+The converse problem is somewhat more complicated: Find the curves which
+admit a given curve $C$ as involute.  Such curves are called
+<i>evolutes</i> of $C$ (German: <i>Evolute;</i> French:
+<i>d&eacute;velopp&eacute;es</i>).  Their tangents are normal to $C({\bf
+x})$ and we can therefore write the equation of the evolute ${\bf y}$ (Fig.
+1-34):
+
+$$
+{\bf y} = {\bf x} + a_1{\bf n} + a_2{\bf b}.
+$$
+
+Hence
+
+$$
+{d{\bf y}\over ds} = {\bf t}(1-a_1\kappa) + {\bf n}\left({da_1\over
+ds}-\tau a_2\right) + {\bf b}\left({da_2\over ds}+\tau a_1\right)
+$$
+
+must have the direction of $a_1{\bf n} + a_2{\bf b}$, this tangent to the
+evolute:
+$$
+\kappa = 1/a, \qquad R= a_1,
+$$
+and
+$$
+{{da_1\over ds} - \tau a_2\over a_1} = {{da_2\over ds}+\tau a_1\over a_2},
+$$
+
+which can be written in the form:
+$$
+{a_2{dR\over ds} - R{da_2\over ds} \over a_2^2 + R^2} = \tau.
+$$
+
+This expression can be integrated:
+$$
+\tan^{-1}{R\over a_2} = \int \tau\,ds + {\rm const},
+$$
+or
+$$
+a_2 = R\left[{\rm cot}\left(\int \tau\,ds + {\rm const}\right)\right].
+$$
+
+The equation of the evolute is:
+$$
+{\bf y} = {\bf x} + R\left[{\bf n} + {\rm cot}\left(\int \tau\,ds + {\rm
+const}\right){\bf b}\right].
+$$
+
+</blockquote>
+
+<!------------------------------------------------------------------------>
+<hr>
+<div id="p154">
+p. 154
+<p>
+
+<blockquote>
+
+If $P(u,v)$ and $Q(u,v)$ are two functions of $u$ and $v$ on a surface,
+then according to Green's theorem and the expression in Chapter 2, Eq.
+(3-4) for the element area:
+
+$$
+\int_C P\,du + Q\, dv =
+ \int\!\!\!\int_A \left({\partial Q\over \partial u} - {\partial P\over
+ \partial v}\right) {1\over \sqrt{EG-F^2}}\,dA,
+$$
+where $dA$ is the element of area of the region $R$ enclosed by the curve
+$C$.  With the aid of this theorem we shall evaluate
+
+$$
+\int_C \kappa_g\,ds,
+$$
+
+where $\kappa_g$ is the geodesic curvature of the curve $C$.  If $C$ at a
+point $P$ makes the angle $\theta$ with the coordinate curve $v = {\rm
+constant}$ and if the coordinate curves are orthogonal, then, according to
+Liouville's formula (1-13):
+$$
+\kappa_g\,ds = d\theta + \kappa_1(\cos\theta)\,ds +
+\kappa_2(\sin\theta)\,ds.
+$$
+
+Here, $\kappa_1$ and $\kappa_2$ are the geodesic curvatures of the curves
+$v = {\rm constant}$ and $u = {\rm constant}$ respectively.  Since
+$$
+\cos\theta\,ds = \sqrt{E}\,du, \qquad \sin\theta\,ds = \sqrt{G}\,dv,
+$$
+we find by application of Green's theorem:
+$$
+\int_C\kappa_g\,ds = \int_C d\theta +
+\int\!\!\!\int_A\left({\partial\over\partial u} \left(\kappa_2\sqrt{G}\,\right) -
+{\partial\over \partial v}\left(\kappa_1\sqrt{E}\,\right)\right)\,du\,dv.
+$$
+
+<p>
+The Gaussian curvature can be written, according to Chapter 3, Eq. (3-7),
+$$
+K = -{1\over 2\sqrt{EG}} \left[{\partial\over\partial u}{G_u\over
+\sqrt{EG}} + {\partial\over\partial v}{E_v\over\sqrt{EG}}\right]
+={1\over\sqrt{EG}}\left[ -{\partial\over\partial u}
+\left(\kappa_2\sqrt{G}\,\right) + {\partial\over\partial v}
+\left(\kappa_1\sqrt{E}\,\right)\right],
+$$
+so we obtain the formula
+$$
+\int_C\kappa_g\,ds = \int_C d\theta - \int\!\!\!\int_A K\,dA.
+$$
+
+The integral $\int\!\!\int_A K\,dA$ is known as the <i>total</i> or
+<i>integral curvature</i>, or <i>curvature integra</i>, of the region $R$,
+the name by which Gauss introduced it.
+
+</blockquote>
+<p>
+</div>
+
+
+<!------------------------------------------------------------------------>
+
+</blockquote>
+
+</body>
+</html>

--- a/examples/Struik-speech.html
+++ b/examples/Struik-speech.html
@@ -9,7 +9,7 @@
 MathJax.Hub.Config({
   tex2jax: {inlineMath: [['$','$'],['\\(','\\)']]},
   SemanticCollapse: {autoCollapse: true},
-  AssistiveMML: {disabled: true},
+  AssistiveMML: {disabled: true}
 });
 MathJax.Ajax.config.path["RespEq"] = "../extensions"
 MathJax.Hub.config.extensions.push(

--- a/extensions/Semantic-Collapse.js
+++ b/extensions/Semantic-Collapse.js
@@ -146,16 +146,16 @@
     //  MathJax internal format, with collapsing).
     //
     Filter: function (jax,id,script) {
-      if (jax.enriched &&
-             (jax.root.Get("display") === "block" ||
-              script.parentNode.childNodes.length <= 3)) {
-        if (jax.enriched.nodeName.toLowerCase() !== "math") {
-          var math = document.createElement("math");
-          math.appendChild(jax.enriched);
-          jax.enriched = math;
-        }
-        jax.root = this.MakeMML(jax.enriched);
-        jax.root.inputID = script.id;
+      if (!jax.enriched) { return; }
+      if (jax.enriched.nodeName.toLowerCase() !== "math") {
+        var math = document.createElement("math");
+        math.appendChild(jax.enriched);
+        jax.enriched = math;
+      }
+      jax.root = this.MakeMML(jax.enriched);
+      jax.root.inputID = script.id;
+      if (jax.root.Get("display") === "block" ||
+          script.parentNode.childNodes.length <= 3) {
         jax.root.SRE = {action: this.Actions(jax.root)};
       }
     },

--- a/extensions/Semantic-Collapse.js
+++ b/extensions/Semantic-Collapse.js
@@ -147,11 +147,6 @@
     //
     Filter: function (jax,id,script) {
       if (!jax.enriched) { return; }
-      if (jax.enriched.nodeName.toLowerCase() !== "math") {
-        var math = document.createElement("math");
-        math.appendChild(jax.enriched);
-        jax.enriched = math;
-      }
       jax.root = this.MakeMML(jax.enriched);
       jax.root.inputID = script.id;
       if (jax.root.Get("display") === "block" ||


### PR DESCRIPTION
* Inline expressions now also use the enriched MathML as internal format.
* They get mactions and can be collapsed manually, but are not collapsed automatically. 
* A version of the Struik example (Struick-speech.html) demonstrates the effect.

I still feel that this logic should be refactored to Semantic-MathML. I.e., the internal format should be reset in the Filter method there and the MakeMML method should be moved. I am just not quite sure what the AddChildren method does, that uses MakeMML as well.

@dpvc Any objections?