### PR TITLE
Handle the default key names properly.

### DIFF
--- a/extensions/Assistive-Explore.js
+++ b/extensions/Assistive-Explore.js
@@ -32,7 +32,8 @@ MathJax.Hub.Register.StartupHook('Sre Ready', function() {
     },
 
     addDefaults: function() {
-      for (var key in Object.keys(Assistive.default)) {
+      var keys = Object.keys(Assistive.default);
+      for (var i = 0, key; key = keys[i]; i++) {
         if (typeof(SETTINGS[Assistive.prefix + key]) === 'undefined') {
           Assistive.addMenuOption(key, Assistive.default[key]);
         }


### PR DESCRIPTION
This fixes the problem with Struik and the walker, where the defaults were not being set properly, so the colors for foreground and background weren't getting set.

The problem was that `Object.keys()` returns an array, so `var keys in Object.keys(...)` was returning indices rather than the names themselves.  This fixes it to get the array of keys and then loop through the indices.