### PR TITLE
Fix timing problem with refactored code

### DIFF
--- a/examples/Struik.html
+++ b/examples/Struik.html
@@ -7,15 +7,19 @@
 
 <script type="text/x-mathjax-config">
 MathJax.Hub.Config({
-  tex2jax: {inlineMath: [['$','$'],['\\(','\\)']]},
-  menuSettings: {'Assistive-generateSpeech': false,
-                 'Assistive-walker': 'syntactic'
+  tex2jax: {
+    inlineMath: [['$','$'],['\\(','\\)']]
+  },
+  menuSettings: {
+    'Assistive-generateSpeech': false,
+    'Assistive-walker': 'syntactic'
   }
 });
-MathJax.Ajax.config.path["RespEq"] = "../extensions"
+MathJax.Ajax.config.path["RespEq"] = "../extensions";
 MathJax.Hub.config.extensions.push(
-"[RespEq]/Assistive-Explore.js",
-"[RespEq]/Semantic-Collapse.js");
+  "[RespEq]/Assistive-Explore.js",
+  "[RespEq]/Semantic-Collapse.js"
+);
 </script>
 <script src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML-full"></script>
 </head>

--- a/extensions/Semantic-Collapse.js
+++ b/extensions/Semantic-Collapse.js
@@ -388,12 +388,12 @@ MathJax.Hub.Register.StartupHook("NativeMML Jax Ready",function () {
 
 //
 //  Load the Semantic-Compmlexity extension and
-//  start up when that has loaded.
+//  signal the start up when that has loaded.
 //
 MathJax.Ajax.Require("[RespEq]/Semantic-Complexity.js");
 MathJax.Hub.Register.StartupHook("Semantic Complexity Ready", function () {
   MathJax.Extension.SemanticCollapse.Startup(); // Initialize the collapsing process
   MathJax.Hub.Startup.signal.Post("Semantic Collapse Ready");
+  MathJax.Ajax.loadComplete("[RespEq]/Semantic-Collapse.js");
 });
 
-MathJax.Ajax.loadComplete("[RespEq]/Semantic-Collapse.js");

--- a/extensions/Semantic-Complexity.js
+++ b/extensions/Semantic-Complexity.js
@@ -624,6 +624,6 @@ MathJax.Hub.Register.StartupHook("Semantic MathML Ready", function () {
   //  Signal that we are ready
   //
   MathJax.Hub.Startup.signal.Post("Semantic Complexity Ready");
+  MathJax.Ajax.loadComplete("[RespEq]/Semantic-Complexity.js");
 });
 
-MathJax.Ajax.loadComplete("[RespEq]/Semantic-Complexity.js");

--- a/extensions/Semantic-MathML.js
+++ b/extensions/Semantic-MathML.js
@@ -146,8 +146,8 @@ MathJax.Callback.Queue(
     //
     MathJax.Hub.postInputHooks.Add(["Filter",MathJax.Extension.SemanticMathML],50);
     MathJax.Hub.Startup.signal.Post("Semantic MathML Ready");
+    MathJax.Ajax.loadComplete("[RespEq]/Semantic-MathML.js");
   }
 );
 
-MathJax.Ajax.loadComplete("[RespEq]/Semantic-MathML.js");
 


### PR DESCRIPTION
This pull request moves `loadComplete()` calls to after the extensions are ready (to get proper synchronization with the startup sequence).  Fixes the timing problem that Volker and Peter were experiencing.