### PR TITLE
Fixes the issue that flaming would only work on one element.

### DIFF
--- a/extensions/Assistive-Explore.js
+++ b/extensions/Assistive-Explore.js
@@ -313,7 +313,6 @@ MathJax.Hub.Register.StartupHook('Sre Ready', function() {
     // Activates Flaming
     //
     Flame: function(node) {
-      Explorer.UnFlame(node);
       if (Assistive.getOption('highlight') === 'flame') {
         Explorer.GetHighlighter(.05);
         Explorer.highlighter.highlightAll(node);
@@ -321,13 +320,14 @@ MathJax.Hub.Register.StartupHook('Sre Ready', function() {
         return;
       }
     },
-    UnFlame: function(node) {
+    UnFlame: function() {
       if (Explorer.flamer) {
         Explorer.highlighter.unhighlightAll();
         Explorer.flamer = null;
       }
     },
     FlameEnriched: function() {
+      Explorer.UnFlame();
       for (var i = 0, all = MathJax.Hub.getAllJax(), jax; jax = all[i]; i++) {
         Explorer.Flame(document.getElementById(jax.inputID).previousSibling);
       }

--- a/extensions/Assistive-Explore.js
+++ b/extensions/Assistive-Explore.js
@@ -464,6 +464,7 @@ MathJax.Hub.Register.StartupHook('Sre Ready', function() {
   });
 
   MathJax.Hub.Register.MessageHook('New Math', ['Register', MathJax.Extension.Assistive.Explorer]);
+  MathJax.Hub.Register.MessageHook('End Math', ['Reset', MathJax.Extension.Assistive.Explorer]);
 
   MathJax.Hub.Startup.signal.Post("Explorer Ready");
 });

--- a/extensions/Assistive-Explore.js
+++ b/extensions/Assistive-Explore.js
@@ -229,6 +229,7 @@ MathJax.Hub.Register.StartupHook('Sre Ready', function() {
             }
           }
           //
+          Explorer.Flame(math);
           math.addEventListener(
             Explorer.focusEvent,
             function(event) {
@@ -329,7 +330,7 @@ MathJax.Hub.Register.StartupHook('Sre Ready', function() {
     FlameEnriched: function() {
       Explorer.UnFlame();
       for (var i = 0, all = MathJax.Hub.getAllJax(), jax; jax = all[i]; i++) {
-        Explorer.Flame(document.getElementById(jax.inputID).previousSibling);
+        Explorer.Flame(jax.SourceElement().previousSibling);
       }
     },
     // 
@@ -464,7 +465,6 @@ MathJax.Hub.Register.StartupHook('Sre Ready', function() {
   });
 
   MathJax.Hub.Register.MessageHook('New Math', ['Register', MathJax.Extension.Assistive.Explorer]);
-  MathJax.Hub.Register.MessageHook('End Math', ['Reset', MathJax.Extension.Assistive.Explorer]);
 
   MathJax.Hub.Startup.signal.Post("Explorer Ready");
 });


### PR DESCRIPTION
Classic example where a compiler would help. Closure would immediately flag a warning unused parameter 'node' .