### PR TITLE
Don't descend into text nodes or nodes with no content.  Resolves issue #98

### DIFF
--- a/extensions/Semantic-Collapse.js
+++ b/extensions/Semantic-Collapse.js
@@ -55,7 +55,7 @@
       return this.sortActions(actions);
     },
     getActions: function (node,depth,actions) {
-      if (node.isToken) return;
+      if (node.isToken || !node.data) return;
       depth++;
       for (var i = 0, m = node.data.length; i < m; i++) {
         if (node.data[i]) {


### PR DESCRIPTION
This fixes a problem with `<annotation>` elements throwing an error.  Resolves issue #98.